### PR TITLE
Clean stale project scaffolding

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -13,15 +13,7 @@
     <inspection_tool class="PyMissingTypeHintsInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="m_onlyWhenTypesAreKnown" value="false" />
     </inspection_tool>
-    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoredPackages">
-        <value>
-          <list size="1">
-            <item index="0" class="java.lang.String" itemvalue="shippo" />
-          </list>
-        </value>
-      </option>
-    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="ignoredErrors">
         <list>
@@ -30,13 +22,7 @@
         </list>
       </option>
     </inspection_tool>
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoredIdentifiers">
-        <list>
-          <option value="bs4.element.PageElement.*" />
-        </list>
-      </option>
-    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/repairshopr_sync/repairshopr_data/tests.py
+++ b/repairshopr_sync/repairshopr_data/tests.py
@@ -1,3 +1,0 @@
-# from django.test import TestCase
-
-# Create your tests here.

--- a/repairshopr_sync/repairshopr_data/views.py
+++ b/repairshopr_sync/repairshopr_data/views.py
@@ -1,3 +1,0 @@
-# from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
## Summary
- Remove empty Django-generated `tests.py` and `views.py` placeholders from `repairshopr_data`.
- Drop stale PyCharm inspection exceptions for `shippo` and `bs4.element.PageElement.*`, which are no longer referenced in this repo.

Refs #9

## Validation
- `./scripts/check-lockfile.sh`
- `uv run pytest -q` (`97 passed, 1 skipped`, coverage 84.01%)
- `uv build`
- `git diff --check`
- PyCharm touched-file inspection: clean after warm rerun

## Notes
This is a first narrow cleanup slice. I intentionally left broader behavior-sensitive candidates alone, including the root `run_django.py` shim, Docker/runtime files, migration history, and docs policy duplication.
