### PR TITLE
Add Dokploy deploy workflow

### DIFF
--- a/.github/workflows/deploy-dokploy.yml
+++ b/.github/workflows/deploy-dokploy.yml
@@ -1,0 +1,54 @@
+---
+name: Deploy to Dokploy
+
+"on":
+  workflow_run:
+    workflows:
+      - Test Suite
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dokploy-deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy cm-repairshopr-sync
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+
+    steps:
+      - name: Trigger Dokploy compose deployment
+        env:
+          DOKPLOY_HOST: ${{ secrets.DOKPLOY_HOST }}
+          DOKPLOY_TOKEN: ${{ secrets.DOKPLOY_TOKEN }}
+          DOKPLOY_COMPOSE_ID: ${{ secrets.DOKPLOY_COMPOSE_ID }}
+        run: |
+          set -euo pipefail
+
+          for name in DOKPLOY_HOST DOKPLOY_TOKEN DOKPLOY_COMPOSE_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "Missing required secret: ${name}" >&2
+              exit 1
+            fi
+          done
+
+          host="${DOKPLOY_HOST%/}"
+          payload=$(jq -n \
+            --arg composeId "$DOKPLOY_COMPOSE_ID" \
+            '{composeId: $composeId}')
+
+          curl --fail --show-error --silent \
+            --request POST \
+            --header "Content-Type: application/json" \
+            --header "x-api-key: ${DOKPLOY_TOKEN}" \
+            --data "$payload" \
+            "${host}/api/compose.deploy"


### PR DESCRIPTION
## Summary
- add a Deploy to Dokploy workflow that triggers after the main-branch Test Suite succeeds
- call Dokploy's compose deploy API for the cm-repairshopr-sync target using GitHub secrets
- keep deployments serialized with a main-branch deploy concurrency group

## Live config
- disabled Dokploy native autoDeploy for cm-repairshopr-sync and verified it is now false
- added repo secrets DOKPLOY_HOST, DOKPLOY_TOKEN, and DOKPLOY_COMPOSE_ID

## Validation
- ruby YAML parse for .github/workflows/deploy-dokploy.yml
- actionlint -shellcheck= .github/workflows/deploy-dokploy.yml
- yamllint .github/workflows/deploy-dokploy.yml