### PR TITLE
Harden Dokploy deploy workflow error handling

### DIFF
--- a/.github/workflows/deploy-dokploy.yml
+++ b/.github/workflows/deploy-dokploy.yml
@@ -58,12 +58,25 @@ jobs:
           }
 
           dokploy_post() {
-            curl --fail --show-error --silent \
+            response=$(curl --fail --show-error --silent \
               --request POST \
               --header "Content-Type: application/json" \
               --header "x-api-key: ${DOKPLOY_TOKEN}" \
               --data "$2" \
-              "$1"
+              "$1")
+
+            if jq -e '
+              type == "object" and (
+                .success == false or
+                has("error") or
+                has("errors")
+              )
+            ' <<< "$response" >/dev/null; then
+              echo "Dokploy write failed: ${response}" >&2
+              return 1
+            fi
+
+            printf '%s' "$response"
           }
 
           github_request() {
@@ -199,7 +212,9 @@ jobs:
             case "$deployment_status" in
               done|success|succeeded|completed|finished|healthy)
                 trap - EXIT
-                restore_source_branch
+                if ! restore_source_branch; then
+                  echo "::warning::Deploy succeeded; branch restore failed."
+                fi
                 exit 0
                 ;;
               error|failed|failure|cancelled|canceled)


### PR DESCRIPTION
## Summary
- fail Dokploy mutation steps when the API returns a JSON error body even with a 2xx HTTP response
- keep branch restoration best-effort after a successful Dokploy deployment so cleanup errors do not mask a successful deploy

## Validation
- ruby YAML parse for .github/workflows/deploy-dokploy.yml
- actionlint .github/workflows/deploy-dokploy.yml
- yamllint .github/workflows/deploy-dokploy.yml

## Context
- addresses auto-review findings after the pinned Dokploy deployment workflow landed