### PR TITLE
Add Launchplane config authority gate

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -23,6 +23,12 @@
       "check": "./scripts/check-lockfile.sh",
       "refresh": "uv lock"
     },
+    "configAuthority": {
+      "launchplaneRef": "65d5695e48db61d3e491762e957a9f8101c3bf81",
+      "productCheckoutPath": "product-repo",
+      "launchplaneCheckoutPath": "launchplane",
+      "ciCommand": "cd launchplane && uv run launchplane service audit-config-authority --control-plane-root ../product-repo --mode changed-files-gate --fail-on-findings --gate-profile product-repo"
+    },
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,42 @@ permissions:
   contents: read
 
 jobs:
+  launchplane-config-authority:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          path: product-repo
+          fetch-depth: 0
+
+      - name: Check out Launchplane
+        uses: actions/checkout@v6
+        with:
+          repository: cbusillo/launchplane
+          ref: 65d5695e48db61d3e491762e957a9f8101c3bf81
+          path: launchplane
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Run Launchplane config authority gate
+        working-directory: launchplane
+        run: |
+          uv run launchplane service audit-config-authority \
+            --control-plane-root ../product-repo \
+            --mode changed-files-gate \
+            --fail-on-findings \
+            --gate-profile product-repo
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

- add a `launchplane-config-authority` CI job that runs Launchplane's product-repo changed-file authority gate
- checkout the product repo with full history so Launchplane can compute the PR diff against `origin/main`
- pin the Launchplane scanner checkout to `65d5695e48db61d3e491762e957a9f8101c3bf81`
- record the CI gate layout in `.github/github.json` without making Launchplane runtime authority local to this repo

Refs cbusillo/launchplane#1200.

## Validation

- `actionlint .github/workflows/tests.yml`
- `jq empty .github/github.json`
- Launchplane gate from Launchplane checkout:
  - `finding_count=60`
  - `rejected=0`
  - `gate=pass`
- `./scripts/check-lockfile.sh`
- `uv run pytest -q` -> `99 passed, 1 skipped`, coverage `84.01%`
- PyCharm inspection closeout:
  - route: `PyCharm 2026.1.2`, project `repairshopr_api`
  - scope: changed files
  - status: clean
  - total problems: 0
  - cleanup: closed
- `git diff --check`

## Notes

This is the first non-Odoo product repo rollout for the Launchplane product-repo config authority gate. During rollout, the initial Launchplane gate was refined in cbusillo/launchplane#1275 so product-owned CI service credentials such as MySQL test passwords do not fail as Launchplane managed-secret authority.
