### PR TITLE
Expose sync health port for Launchplane routing

### DIFF
--- a/docker/coolify/compose.yml
+++ b/docker/coolify/compose.yml
@@ -17,8 +17,12 @@ services:
       SYNC_DB_USER: ${SYNC_DB_USER:-repairshopr_api}
       SYNC_DB_PASSWORD: ${SYNC_DB_PASSWORD}
       SYNC_INTERVAL_SECONDS: ${SYNC_INTERVAL_SECONDS:-900}
+      SYNC_HEALTH_BIND_ADDRESS: ${SYNC_HEALTH_BIND_ADDRESS:-0.0.0.0}
+      SYNC_HEALTH_PORT: ${SYNC_HEALTH_PORT:-8000}
     depends_on:
       - db
+    expose:
+      - "${SYNC_HEALTH_PORT:-8000}"
     restart: unless-stopped
     volumes:
       - repairshopr_sync_config:/var/lib/repairshopr/.config

--- a/tests/test_compose_contract.py
+++ b/tests/test_compose_contract.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_PATH = ROOT / "docker" / "coolify" / "compose.yml"
+GITHUB_JSON_PATH = ROOT / ".github" / "github.json"
+
+
+def test_sync_compose_declares_internal_health_port_without_host_publish() -> None:
+    compose_text = COMPOSE_PATH.read_text(encoding="utf-8")
+
+    assert "SYNC_HEALTH_BIND_ADDRESS: ${SYNC_HEALTH_BIND_ADDRESS:-0.0.0.0}" in compose_text
+    assert "SYNC_HEALTH_PORT: ${SYNC_HEALTH_PORT:-8000}" in compose_text
+    assert 'expose:\n      - "${SYNC_HEALTH_PORT:-8000}"' in compose_text
+    assert '"${SYNC_HEALTH_PORT:-8000}:${SYNC_HEALTH_PORT:-8000}"' not in compose_text
+    assert "traefik." not in compose_text
+    assert "caddy." not in compose_text
+    assert "nginx." not in compose_text
+
+
+def test_launchplane_metadata_does_not_store_live_health_urls() -> None:
+    github_json_text = GITHUB_JSON_PATH.read_text(encoding="utf-8")
+
+    assert '"healthUrls": []' in github_json_text


### PR DESCRIPTION
## Summary
- declare the sync health bind/port env contract in the Coolify compose service
- expose the sync health port internally without publishing a host port or adding proxy labels
- add a compose contract test that keeps live health URLs out of repo metadata

## Verification
- `uv run pytest -q --no-cov tests/test_compose_contract.py tests/scripts/test_sync_with_health_wrapper.py tests/sync/test_health_readiness.py`
- `uv run pytest -q`
- scoped agent review: no blocking findings

## Notes
- Launchplane product/profile/edge records still own the real health URL, provider target, and public routing. This PR only exposes the product repo's generic internal health surface.
- Launchplane config-authority changed-files audit flags pre-existing compose env placeholders in `docker/coolify/compose.yml` when the file is touched; this patch does not add live URLs, provider IDs, domains, or secrets.