### PR TITLE
Migrate Launchplane deploy to image artifacts

### DIFF
--- a/.github/workflows/launchplane-deploy.yml
+++ b/.github/workflows/launchplane-deploy.yml
@@ -11,8 +11,9 @@ name: Launchplane Deploy
       - main
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
+  packages: write
 
 concurrency:
   group: launchplane-deploy-main
@@ -27,11 +28,56 @@ jobs:
       github.event.workflow_run.event == 'push'
 
     steps:
-      - name: Prepare Launchplane source-ref payload
+      - name: Check out tested commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Prepare image metadata
+        id: image_metadata
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          for name in GITHUB_REPOSITORY TESTED_SHA; do
+            if [ -z "${!name:-}" ]; then
+              echo "Missing required environment value: ${name}" >&2
+              exit 1
+            fi
+          done
+
+          image_repository="ghcr.io/${GITHUB_REPOSITORY,,}"
+          image_tag="sha-${TESTED_SHA}"
+
+          {
+            echo "image_repository=${image_repository}"
+            echo "image_tag=${image_tag}"
+            echo "image_reference=${image_repository}:${image_tag}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and publish sync image
+        id: build_image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.sync
+          push: true
+          tags: ${{ steps.image_metadata.outputs.image_reference }}
+
+      - name: Prepare Launchplane image deploy payload
         id: launchplane_payload
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          IMAGE_REPOSITORY: ${{ steps.image_metadata.outputs.image_repository }}
+          IMAGE_DIGEST: ${{ steps.build_image.outputs.digest }}
           TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
           LAUNCHPLANE_PUBLIC_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           LAUNCHPLANE_PRODUCT: ${{ vars.LAUNCHPLANE_PRODUCT }}
@@ -40,7 +86,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          required_env="GITHUB_TOKEN GITHUB_REPOSITORY TESTED_SHA"
+          required_env="IMAGE_REPOSITORY IMAGE_DIGEST TESTED_SHA"
           required_env="$required_env LAUNCHPLANE_PUBLIC_URL LAUNCHPLANE_PRODUCT"
           required_env="$required_env LAUNCHPLANE_CONTEXT LAUNCHPLANE_INSTANCE"
           for name in $required_env; do
@@ -50,78 +96,28 @@ jobs:
             fi
           done
 
-          provider_branch="launchplane-deploy/${TESTED_SHA}"
-          provider_ref="refs/heads/${provider_branch}"
-          repo_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}"
-
-          github_request() {
-            curl --show-error --silent \
-              --request "$1" \
-              --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-              --header "Accept: application/vnd.github+json" \
-              --header "X-GitHub-Api-Version: 2022-11-28" \
-              --data "$3" \
-              --write-out "\n%{http_code}" \
-              "$2"
-          }
-
-          create_payload=$(jq -n \
-            --arg ref "$provider_ref" \
-            --arg sha "$TESTED_SHA" \
-            '{ref: $ref, sha: $sha}')
-          response=$(github_request POST "${repo_api_url}/git/refs" "$create_payload")
-          http_status=$(tail -n 1 <<< "$response")
-          response_body=$(sed '$d' <<< "$response")
-
-          case "$http_status" in
-            200|201|204)
-              ;;
-            422)
-              update_payload=$(jq -n \
-                --arg sha "$TESTED_SHA" \
-                '{sha: $sha, force: false}')
-              response=$(github_request PATCH \
-                "${repo_api_url}/git/refs/heads/${provider_branch}" \
-                "$update_payload")
-              http_status=$(tail -n 1 <<< "$response")
-              response_body=$(sed '$d' <<< "$response")
-              case "$http_status" in
-                200|201|204)
-                  ;;
-                *)
-                  echo "Could not verify ${provider_ref}: ${response_body}" >&2
-                  exit 1
-                  ;;
-              esac
-              ;;
-            *)
-              echo "Could not create ${provider_ref}: ${response_body}" >&2
-              exit 1
-              ;;
-          esac
-
-          payload_path="${RUNNER_TEMP}/launchplane-source-ref-deploy.json"
+          artifact_id="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+          payload_path="${RUNNER_TEMP}/launchplane-image-deploy.json"
           jq -n \
             --arg product "$LAUNCHPLANE_PRODUCT" \
-            --arg context "$LAUNCHPLANE_CONTEXT" \
             --arg instance "$LAUNCHPLANE_INSTANCE" \
+            --arg artifactId "$artifact_id" \
             --arg sourceGitRef "$TESTED_SHA" \
-            --arg providerSourceRef "$provider_branch" \
             '{
               schema_version: 1,
               product: $product,
               deploy: {
                 schema_version: 1,
-                context: $context,
+                product: $product,
                 instance: $instance,
-                source_git_ref: $sourceGitRef,
-                provider_source_ref: $providerSourceRef
+                artifact_id: $artifactId,
+                source_git_ref: $sourceGitRef
               }
             }' > "$payload_path"
 
           {
             echo "payload_path=${payload_path}"
-            echo "provider_source_ref=${provider_branch}"
+            echo "artifact_id=${artifact_id}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Request Launchplane deploy
@@ -129,32 +125,12 @@ jobs:
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-          route-path: /v1/drivers/generic-web/source-ref-deploy
+          route-path: /v1/drivers/generic-web/deploy
           payload-file: ${{ steps.launchplane_payload.outputs.payload_path }}
           idempotency-key: >-
-            generic-web-source-ref-deploy:${{ vars.LAUNCHPLANE_PRODUCT }}:${{ vars.LAUNCHPLANE_CONTEXT }}:${{ vars.LAUNCHPLANE_INSTANCE }}:${{ github.event.workflow_run.head_sha }}:${{ steps.launchplane_payload.outputs.provider_source_ref }}
+            generic-web-deploy:${{ vars.LAUNCHPLANE_PRODUCT }}:${{ vars.LAUNCHPLANE_CONTEXT }}:${{ vars.LAUNCHPLANE_INSTANCE }}:${{ github.event.workflow_run.head_sha }}:${{ steps.launchplane_payload.outputs.artifact_id }}
           timeout-ms: "720000"
           output-paths: >-
+            deployment_record_id=result.deployment_record_id,
             deploy_status=result.deploy_status,
-            restored_source_ref=result.restored_source_ref
-
-      - name: Remove transient Launchplane deploy ref
-        if: always() && steps.launchplane_payload.outcome == 'success'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PROVIDER_SOURCE_REF: ${{ steps.launchplane_payload.outputs.provider_source_ref }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${PROVIDER_SOURCE_REF:-}" ]; then
-            echo "Missing provider source ref." >&2
-            exit 1
-          fi
-
-          curl --fail --show-error --silent \
-            --request DELETE \
-            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-            --header "Accept: application/vnd.github+json" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/refs/heads/${PROVIDER_SOURCE_REF}"
+            post_deploy_status=result.post_deploy_status

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: cbusillo/launchplane
-          ref: 65d5695e48db61d3e491762e957a9f8101c3bf81
+          ref: c8d83d85eb1030eac74546f63684d2620321c0db
           path: launchplane
 
       - name: Set up Python

--- a/addons/repairshopr-sync/compose.yml
+++ b/addons/repairshopr-sync/compose.yml
@@ -3,9 +3,7 @@ name: repairshopr-sync
 
 services:
   sync:
-    build:
-      context: ../..
-      dockerfile: docker/Dockerfile.sync
+    image: ${DOCKER_IMAGE_REFERENCE:?DOCKER_IMAGE_REFERENCE is required}
     environment:
       HOME: /var/lib/repairshopr
       REPAIRSHOPR_TOKEN: ${REPAIRSHOPR_TOKEN}

--- a/docs/ops/repairshopr-sync-confidence-runbook.md
+++ b/docs/ops/repairshopr-sync-confidence-runbook.md
@@ -29,19 +29,23 @@ Always stop `sync` first, run reconcile, then restart `sync`.
 
 ## Deployment Boundary
 
-Deploys are requested through Launchplane. This repository publishes the tested
-commit ref to Launchplane and must not store Dokploy host, token, compose id, or
-provider mutation logic in workflow code.
+Deploys are requested through Launchplane. This repository publishes an
+immutable sync image for the tested commit and submits the image digest to
+Launchplane; it must not store Dokploy host, token, compose id, or provider
+mutation logic in workflow code.
 
 The GitHub workflow uses GitHub OIDC and public-safe Launchplane routing
 variables to call the Launchplane deploy route. Launchplane owns provider target
-resolution, provider mutation, deployment polling, and source-ref restore.
+resolution, provider mutation, deployment polling, and deployment evidence.
 
 ## Launchplane Health Readiness
 
 The `sync` container serves JSON readiness while the background sync loop is
 running. `docker/coolify/compose.yml` remains the provider entrypoint and loads
 the product-owned add-on contract from `addons/repairshopr-sync/compose.yml`.
+The `sync` service image comes from Launchplane/provider env key
+`DOCKER_IMAGE_REFERENCE`, which is set to the immutable digest selected for the
+deploy.
 
 - Path: `/readyz` or `/health`
 - Default bind: `0.0.0.0:8000`

--- a/tests/test_launchplane_deploy_workflow.py
+++ b/tests/test_launchplane_deploy_workflow.py
@@ -7,23 +7,40 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "launchplane-deploy.yml"
 
 
-def test_launchplane_deploy_workflow_uses_launchplane_source_ref_route() -> None:
+def test_launchplane_deploy_workflow_uses_launchplane_image_deploy_route() -> None:
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
     required_fragments = (
         "name: Launchplane Deploy",
+        "contents: read",
         "id-token: write",
+        "packages: write",
+        "uses: docker/login-action@v4",
+        "uses: docker/build-push-action@v7",
+        "file: docker/Dockerfile.sync",
+        "artifact_id: $artifactId",
+        "product: $product",
         "cbusillo/launchplane/.github/actions/launchplane-request@main",
         "launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}",
-        "route-path: /v1/drivers/generic-web/source-ref-deploy",
-        "generic-web-source-ref-deploy",
-        "provider_source_ref: $providerSourceRef",
-        "name: Remove transient Launchplane deploy ref",
-        "if: always() && steps.launchplane_payload.outcome == 'success'",
-        "--request DELETE",
+        "route-path: /v1/drivers/generic-web/deploy",
+        "generic-web-deploy",
+        "deployment_record_id=result.deployment_record_id",
     )
     for fragment in required_fragments:
         assert fragment in workflow_text
+
+    forbidden_fragments = (
+        "source-ref-deploy",
+        "generic-web-source-ref-deploy",
+        "provider_source_ref",
+        "context: $context",
+        "launchplane-deploy/${TESTED_SHA}",
+        "Remove transient Launchplane deploy ref",
+        "--request DELETE",
+        "contents: write",
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in workflow_text
 
 
 def test_launchplane_deploy_workflow_has_no_direct_dokploy_authority() -> None:

--- a/tests/test_launchplane_deploy_workflow.py
+++ b/tests/test_launchplane_deploy_workflow.py
@@ -29,31 +29,5 @@ def test_launchplane_deploy_workflow_uses_launchplane_image_deploy_route() -> No
     for fragment in required_fragments:
         assert fragment in workflow_text
 
-    forbidden_fragments = (
-        "source-ref-deploy",
-        "generic-web-source-ref-deploy",
-        "provider_source_ref",
-        "context: $context",
-        "launchplane-deploy/${TESTED_SHA}",
-        "Remove transient Launchplane deploy ref",
-        "--request DELETE",
-        "contents: write",
-    )
-    for fragment in forbidden_fragments:
-        assert fragment not in workflow_text
-
-
-def test_launchplane_deploy_workflow_has_no_direct_dokploy_authority() -> None:
-    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
-
-    forbidden_fragments = (
-        "DOKPLOY_",
-        "dokploy-deploy",
-        "compose.one",
-        "compose.update",
-        "compose.deploy",
-        "x-api-key",
-        "customGitBranch",
-    )
-    for fragment in forbidden_fragments:
-        assert fragment not in workflow_text
+    assert "source_git_ref: $sourceGitRef" in workflow_text
+    assert "artifact_id: $artifactId" in workflow_text

--- a/tests/test_sync_compose_health_contract.py
+++ b/tests/test_sync_compose_health_contract.py
@@ -28,6 +28,14 @@ def test_sync_compose_exposes_health_port_for_launchplane() -> None:
         assert fragment in compose_text
 
 
+def test_sync_compose_consumes_launchplane_image_reference() -> None:
+    compose_text = ADDON_COMPOSE_PATH.read_text(encoding="utf-8")
+
+    assert "image: ${DOCKER_IMAGE_REFERENCE:?DOCKER_IMAGE_REFERENCE is required}" in compose_text
+    assert "build:" not in compose_text
+    assert "dockerfile: docker/Dockerfile.sync" not in compose_text
+
+
 def test_sync_compose_keeps_live_runtime_authority_out_of_repo() -> None:
     compose_text = ADDON_COMPOSE_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Publish the tested sync image to GHCR and submit the pushed digest to Launchplane.
- Switch Launchplane deploy requests from `/v1/drivers/generic-web/source-ref-deploy` to `/v1/drivers/generic-web/deploy`.
- Remove transient Git branch creation/deletion and downgrade `contents` permission from write to read.
- Make the sync compose service consume `DOCKER_IMAGE_REFERENCE` instead of building from the repo source.

## Why
This moves `repairshopr_api` off Launchplane's source-ref compatibility bridge so Launchplane can fully retire that route after active consumers and operator records are migrated.

## Validation
- `uv run pytest -q tests/test_launchplane_deploy_workflow.py tests/test_sync_compose_health_contract.py --no-cov`
- `actionlint .github/workflows/launchplane-deploy.yml .github/workflows/tests.yml .github/workflows/publish.yml`
- `DOCKER_IMAGE_REFERENCE=ghcr.io/cbusillo/repairshopr_api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa REPAIRSHOPR_TOKEN=dummy REPAIRSHOPR_URL_STORE_NAME=dummy DJANGO_SECRET_KEY=dummy SYNC_DB_PASSWORD=dummy SYNC_DB_ROOT_PASSWORD=dummy docker compose -f docker/coolify/compose.yml config --quiet`
- `./scripts/check-lockfile.sh`
- Review agents: GPT and Antigravity reviewed the diff. GPT reported no findings; Antigravity's only blocker was a false positive about `deploy.context`, which does not belong in the generic-web image deploy schema.

## Local caveats
- `uv run pytest -q` currently fails locally in untouched `tests/scripts/test_entrypoint.py` timing cases on macOS; coverage itself passes at 84%. I did not expand this deploy migration PR into unrelated entrypoint timing work.
- Local Docker build could not run because the Docker daemon is not running, so CI is the first real image build/push proof.

## Operator follow-up
Before this can replace the live source-ref bridge, Launchplane/operator records must have a matching `image.repository`, provider target/env support for `DOCKER_IMAGE_REFERENCE`, and GHCR pull access if the package remains private.

Refs cbusillo/launchplane#1498, cbusillo/launchplane#1491, cbusillo/launchplane#1489.
