### PR TITLE
Use reusable Launchplane config authority gate

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -23,12 +23,6 @@
       "check": "./scripts/check-lockfile.sh",
       "refresh": "uv lock"
     },
-    "configAuthority": {
-      "launchplaneRef": "d636cae92120014be35579b7c6c40fef24d85103",
-      "productCheckoutPath": "product-repo",
-      "launchplaneCheckoutPath": "launchplane",
-      "ciCommand": "cd launchplane && uv run launchplane service audit-config-authority --control-plane-root ../product-repo --mode changed-files-gate --fail-on-findings --gate-profile product-repo"
-    },
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,40 +12,7 @@ permissions:
 
 jobs:
   launchplane-config-authority:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-        with:
-          path: product-repo
-          fetch-depth: 0
-
-      - name: Check out Launchplane
-        uses: actions/checkout@v6
-        with:
-          repository: cbusillo/launchplane
-          ref: d636cae92120014be35579b7c6c40fef24d85103
-          path: launchplane
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Run Launchplane config authority gate
-        working-directory: launchplane
-        run: |
-          uv run launchplane service audit-config-authority \
-            --control-plane-root ../product-repo \
-            --mode changed-files-gate \
-            --fail-on-findings \
-            --gate-profile product-repo
+    uses: cbusillo/launchplane/.github/workflows/reusable-product-repo-config-authority.yml@main
 
   test:
     runs-on: ubuntu-latest

--- a/tests/test_launchplane_deploy_workflow.py
+++ b/tests/test_launchplane_deploy_workflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "launchplane-deploy.yml"
+TESTS_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "tests.yml"
 
 
 def test_launchplane_deploy_workflow_uses_reusable_generic_web_deploy() -> None:
@@ -35,6 +36,25 @@ def test_launchplane_deploy_workflow_uses_reusable_generic_web_deploy() -> None:
         "payload-file:",
         "idempotency-key:",
         "deployment_record_id=result.deployment_record_id",
+    )
+    for fragment in repo_local_launchplane_fragments:
+        assert fragment not in workflow_text
+
+
+def test_test_suite_uses_reusable_launchplane_config_authority_gate() -> None:
+    workflow_text = TESTS_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert (
+        "uses: cbusillo/launchplane/.github/workflows/"
+        "reusable-product-repo-config-authority.yml@main"
+    ) in workflow_text
+
+    repo_local_launchplane_fragments = (
+        "repository: cbusillo/launchplane",
+        "launchplaneRef",
+        "audit-config-authority",
+        "--control-plane-root",
+        "--gate-profile product-repo",
     )
     for fragment in repo_local_launchplane_fragments:
         assert fragment not in workflow_text


### PR DESCRIPTION
## Summary
- replace the repo-local Launchplane checkout/audit invocation with Launchplane's reusable product-repo config-authority workflow
- remove the pinned Launchplane audit command metadata from .github/github.json
- extend workflow-shape tests to keep the reusable audit gate in place

## Validation
- actionlint .github/workflows/tests.yml .github/workflows/launchplane-deploy.yml
- jq empty .github/github.json
- uv run pytest -q tests/test_launchplane_deploy_workflow.py --no-cov
- git diff --check